### PR TITLE
Fix: Corrected Delta Exchange payload signature generation for cancel order

### DIFF
--- a/python/ccxt/delta.py
+++ b/python/ccxt/delta.py
@@ -3420,7 +3420,7 @@ class delta(Exchange, ImplicitAPI):
                 'timestamp': timestamp,
             }
             auth = method + timestamp + requestPath
-            if (method == 'GET') or (method == 'DELETE'):
+            if method == 'GET':
                 if query:
                     queryString = '?' + self.urlencode(query)
                     auth += queryString


### PR DESCRIPTION
### Fix: Delta Exchange Cancel Order Payload Signature Issue  

This PR addresses an issue with the payload signature generation for Delta Exchange's cancel order functionality. The `delete` endpoint was incorrectly including parameters in the query string instead of the POST request body, which caused signature mismatches.  

#### Changes:  
- Moved the parameters to the POST body for correct signature generation as per the Delta Exchange API documentation.  
- Ensured that the payload matches the expected structure for the cancel order request.  
- Improved handling to align with API endpoint specifications.  

#### Impact:  
This fix ensures that Delta Exchange cancel order requests are properly signed and handled, resolving issues with payload signature mismatches and improving the functionality of the cancel order feature.  

Please review and let me know if any further adjustments are needed. Thank you!  
